### PR TITLE
Require `fs` on a separate line

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ exports = module.exports = require('./lib/select');
   Export the version
 */
 exports.version = (function() {
-  var pkg = require('fs').readFileSync(__dirname + '/package.json', 'utf8');
+  var fs = require('fs');
+  var pkg = fs.readFileSync(__dirname + '/package.json', 'utf8');
   return JSON.parse(pkg).version;
 })();


### PR DESCRIPTION
browserify-brfs doesn't handle it otherwise: https://github.com/substack/brfs/issues/11
